### PR TITLE
Provide required routeInformationProvider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ class MyAwesomeApp extends ConsumerWidget {
 
     return MaterialApp.router(
       routeInformationParser: router.routeInformationParser,
+      routeInformationProvider: router.routeInformationProvider,
       routerDelegate: router.routerDelegate,
       title: 'flutter_riverpod + go_router Demo',
       theme: ThemeData(


### PR DESCRIPTION
Since v4.0.0 GoRouter requires a 'routeInformationProvider'.
[Documentation](https://docs.google.com/document/d/1T2LmzMj5HpD7hEexXL4Xz6vqoJD81bEGaa9NsV24faw/edit?resourcekey=0-PuQbtDVl7ZabpJ2B9AHWUg)